### PR TITLE
fix/ollama-start-up

### DIFF
--- a/scripts/check_dependencies.sh
+++ b/scripts/check_dependencies.sh
@@ -28,7 +28,9 @@ if ! command -v ollama &>/dev/null; then
         read model_choice
         if [[ "$model_choice" == "y" ]]; then
             echo "Starting Ollama"
-            ollama serve
+            nohup ollama serve &> /dev/null &
+            echo "Ollama service started in the background."
+
             echo "Pulling llama3 model. Strap in, this might take a while."
             ollama pull llama3
             echo "llama3 model downloaded."


### PR DESCRIPTION
## Description
Fixes check_dependencies by running ollama in the background using nohup and logs messages indicating service start and model pull completion.

## Changes
* Adds code to run `ollama serve` in the background using `nohup`
* Logs a message indicating that the service has started
* Pulls the `llama3` model and logs a success message when complete