### PR TITLE
Feature - Jit update

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -25,11 +25,11 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 
 > If you want to ask a question, we assume that you have read the available [Documentation](./README.md).
 
-Before you ask a question, it is best to search for existing [Issues](/issues) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in this issue. It is also advisable to search the internet for answers first.
+Before you ask a question, it is best to search for existing [Issues](https://github.com/gsvh/jit/issues) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in this issue. It is also advisable to search the internet for answers first.
 
 If you then still feel the need to ask a question and need clarification, we recommend the following:
 
-- Open an [Issue](/issues/new).
+- Open an [Issue](https://github.com/gsvh/jit/issues/new).
 - Provide as much context as you can about what you're running into.
 - Provide project and platform versions (nodejs, npm, etc), depending on what seems relevant.
 
@@ -45,7 +45,7 @@ A good bug report shouldn't leave others needing to chase you up for more inform
 
 - Make sure that you are using the latest version.
 - Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](./README.md). If you are looking for support, you might want to check [this section](#i-have-a-question)).
-- To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](issues?q=label%3Abug).
+- To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://github.com/gsvh/jit/issues).
 - Also make sure to search the internet (including Stack Overflow) to see if users outside of the GitHub community have discussed the issue.
 - Collect information about the bug:
 - Stack trace (Traceback)
@@ -60,7 +60,7 @@ A good bug report shouldn't leave others needing to chase you up for more inform
 
 We use GitHub issues to track bugs and errors. If you run into an issue with the project:
 
-- Open an [Issue](/issues/new). (Since we can't be sure at this point whether it is a bug or not, we ask you not to talk about a bug yet and not to label the issue.)
+- Open an [Issue](https://github.com/gsvh/jit/issues/new). (Since we can't be sure at this point whether it is a bug or not, we ask you not to talk about a bug yet and not to label the issue.)
 - Explain the behavior you would expect and the actual behavior.
 - Please provide as much context as possible and describe the _reproduction steps_ that someone else can follow to recreate the issue on their own. This usually includes your code. For good bug reports you should isolate the problem and create a reduced test case.
 - Provide the information you collected in the previous section.
@@ -69,7 +69,7 @@ Once it's filed:
 
 - The project team will label the issue accordingly.
 - A team member will try to reproduce the issue with your provided steps. If there are no reproduction steps or no obvious way to reproduce the issue, the team will ask you for those steps and mark the issue as `needs-repro`. Bugs with the `needs-repro` tag will not be addressed until they are reproduced.
-- If the team is able to reproduce the issue, it will be marked `needs-fix`, as well as possibly other tags (such as `critical`), and the issue will be left to be [implemented by someone](#your-first-code-contribution).
+- If the team is able to reproduce the issue, it will be marked `needs-fix`, as well as possibly other tags (such as `critical`), and the issue will be left to be [implemented by someone](#your-first-code-contribution-🫶).
 
 ### Suggesting Enhancements
 
@@ -79,12 +79,12 @@ This section guides you through submitting an enhancement suggestion for CONTRIB
 
 - Make sure that you are using the latest version.
 - Read the [documentation](./README.md) carefully and find out if the functionality is already covered, maybe by an individual configuration.
-- Perform a [search](/issues) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
+- Perform a [search](https://github.com/gsvh/jit/issues) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
 - Find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to convince the project's developers of the merits of this feature. Keep in mind that we want features that will be useful to the majority of our users and not just a small subset. If you're just targeting a minority of users, consider writing an add-on/plugin library.
 
 #### How Do I Submit a Good Enhancement Suggestion?
 
-Enhancement suggestions are tracked as [GitHub issues](/issues).
+Enhancement suggestions are tracked as [GitHub issues](https://github.com/gsvh/jit/issues).
 
 - Use a **clear and descriptive title** for the issue to identify the suggestion.
 - Provide a **step-by-step description of the suggested enhancement** in as many details as possible.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 
 Before installing jit, ensure you have the following installed:
 
-- Python 3.6 or higher
+- [Python](https://www.python.org/downloads/) 3.6 or higher
 - `pip3` for Python package management
-- Homebrew (for macOS users) to install certain dependencies
+- [Homebrew](https://brew.sh/) (for macOS users) to install certain dependencies
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ To view the welcome message and get started:
 jit welcome
 ```
 
+### Updating jit
+
+To update jit to the latest stable version:
+
+```bash
+jit update
+```
+
 ## Uninstallation
 
 To uninstall **jit** and optionally remove installed dependencies:

--- a/jit/cli.py
+++ b/jit/cli.py
@@ -1,7 +1,8 @@
 import logging
 import os
-
+import subprocess
 import click
+import shutil
 import git
 from rich.logging import RichHandler
 
@@ -88,3 +89,58 @@ def config(repo_name):
         repo = git.Repo(repo_path)
         repo_name = repo.remotes.origin.url.split('/')[-1].replace('.git', '')
     update_config(repo_name)
+
+@jit.command()
+def update():
+    """Fetch the latest changes from the repo and re-install jit."""
+    logging.basicConfig(level=logging.INFO, format=FORMAT, datefmt="[%X]", handlers=[RichHandler()])
+    log = logging.getLogger("rich")
+
+    repo_path = os.getcwd()
+    repo = git.Repo(repo_path)
+    branch = repo.active_branch
+
+    log.info(f"Current branch: {branch.name}")
+
+    # Check if the branch has an upstream set
+    if not branch.tracking_branch():
+        # Set upstream to the default remote branch (origin/main or origin/master)
+        try:
+            remote_branch = repo.remotes.origin.refs.main
+        except AttributeError:
+            remote_branch = repo.remotes.origin.refs.master
+
+        log.info(f"Setting upstream to {remote_branch}")
+        repo.git.branch('--set-upstream-to', remote_branch, branch.name)
+
+    log.info("Fetching the latest changes from the repository...")
+    repo.git.pull()
+
+    log.info("Re-installing the tool using the Makefile...")
+    env = os.environ.copy()
+    env["COLUMNS"] = str(shutil.get_terminal_size().columns)
+    env["PYTHONUNBUFFERED"] = "1"  # Ensures that Python output is not buffered
+    env["FORCE_COLOR"] = "1"  # Force enable ANSI colors
+
+    process = subprocess.Popen(
+        ["make", "re-install"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env  # Pass the modified environment
+    )
+
+    # Wait for the process to complete and get the return code
+    return_code = process.wait()
+
+    if return_code == 0:
+        # Log stdout and stderr directly after waiting for the process to complete
+        stdout, stderr = process.communicate()
+        log.info(stdout)
+        log.info("jit been updated and re-installed successfully 🎉")
+    else:
+        # Log stderr directly after waiting for the process to complete
+        stdout, stderr = process.communicate()
+        log.error(stderr)
+        log.error("An error occurred while re-installing the tool.")        
+

--- a/jit/cli.py
+++ b/jit/cli.py
@@ -96,51 +96,74 @@ def update():
     logging.basicConfig(level=logging.INFO, format=FORMAT, datefmt="[%X]", handlers=[RichHandler()])
     log = logging.getLogger("rich")
 
-    repo_path = os.getcwd()
-    repo = git.Repo(repo_path)
-    branch = repo.active_branch
+    # Capture the original working directory
+    original_dir = os.getcwd()
 
-    log.info(f"Current branch: {branch.name}")
+    # Get the MY_CURRENT_DIR environment variable
+    repo_path = os.getenv('JIT_DIR')
+    
+    if not repo_path:
+        log.error("JIT_DIR environment variable is not set.")
+        return
 
-    # Check if the branch has an upstream set
-    if not branch.tracking_branch():
-        # Set upstream to the default remote branch (origin/main or origin/master)
-        try:
-            remote_branch = repo.remotes.origin.refs.main
-        except AttributeError:
-            remote_branch = repo.remotes.origin.refs.master
+    try:
+        os.chdir(repo_path)
+        repo = git.Repo(repo_path)
+        branch = repo.active_branch
 
-        log.info(f"Setting upstream to {remote_branch}")
-        repo.git.branch('--set-upstream-to', remote_branch, branch.name)
+        log.info(f"Current branch: {branch.name}")
 
-    log.info("Fetching the latest changes from the repository...")
-    repo.git.pull()
+        # Check if the branch has an upstream set
+        if not branch.tracking_branch():
+            # Set upstream to the default remote branch (origin/main or origin/master)
+            try:
+                remote_branch = repo.remotes.origin.refs.main
+            except AttributeError:
+                remote_branch = repo.remotes.origin.refs.master
 
-    log.info("Re-installing the tool using the Makefile...")
-    env = os.environ.copy()
-    env["COLUMNS"] = str(shutil.get_terminal_size().columns)
-    env["PYTHONUNBUFFERED"] = "1"  # Ensures that Python output is not buffered
-    env["FORCE_COLOR"] = "1"  # Force enable ANSI colors
+            log.info(f"Setting upstream to {remote_branch}")
+            repo.git.branch('--set-upstream-to', remote_branch, branch.name)
 
-    process = subprocess.Popen(
-        ["make", "re-install"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        env=env  # Pass the modified environment
-    )
+        # Fetch the latest changes from the remote
+        repo.remotes.origin.fetch()
 
-    # Wait for the process to complete and get the return code
-    return_code = process.wait()
+        # Check if there are any new changes
+        commits_behind = repo.iter_commits(f'{branch.name}..origin/{branch.name}')
+        if not list(commits_behind):
+            log.info("You are already on the latest version 🤘")
+            return
 
-    if return_code == 0:
-        # Log stdout and stderr directly after waiting for the process to complete
-        stdout, stderr = process.communicate()
-        log.info(stdout)
-        log.info("jit been updated and re-installed successfully 🎉")
-    else:
-        # Log stderr directly after waiting for the process to complete
-        stdout, stderr = process.communicate()
-        log.error(stderr)
-        log.error("An error occurred while re-installing the tool.")        
+        log.info("Fetching the latest changes from the branch...")
+        repo.git.pull()
+
+        log.info("Re-installing the tool using the Makefile...")
+        env = os.environ.copy()
+        env["COLUMNS"] = str(shutil.get_terminal_size().columns)
+        env["PYTHONUNBUFFERED"] = "1"  # Ensures that Python output is not buffered
+        env["FORCE_COLOR"] = "1"  # Force enable ANSI colors
+
+        process = subprocess.Popen(
+            ["make", "update"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=env  # Pass the modified environment
+        )
+
+        # Wait for the process to complete and get the return code
+        return_code = process.wait()
+
+        if return_code == 0:
+            # Log stdout and stderr directly after waiting for the process to complete
+            stdout, stderr = process.communicate()
+            log.info(stdout)
+            log.info("jit has been updated and re-installed successfully 🎉")
+        else:
+            # Log stderr directly after waiting for the process to complete
+            stdout, stderr = process.communicate()
+            log.error(stderr)
+            log.error("An error occurred while updating jit.")     
+    finally:
+        # Change back to the original directory
+        os.chdir(original_dir)
 

--- a/jit/cli.py
+++ b/jit/cli.py
@@ -99,7 +99,7 @@ def update():
     # Capture the original working directory
     original_dir = os.getcwd()
 
-    # Get the MY_CURRENT_DIR environment variable
+    # Get the JIT_DIR environment variable
     repo_path = os.getenv('JIT_DIR')
     
     if not repo_path:

--- a/jit/utils.py
+++ b/jit/utils.py
@@ -34,7 +34,11 @@ def banner():
     jit = make_purple(jit)
 
     jit_lines = jit.split("\n")
-    terminal_width = os.get_terminal_size().columns 
+    # Attempt to get terminal size, with a fallback
+    try:
+        terminal_width = os.get_terminal_size().columns
+    except OSError:
+        terminal_width = 80  # Fallback width
     banner_width = int(terminal_width / 2)
     if banner_width < 50:
         banner_width = 50

--- a/makefile
+++ b/makefile
@@ -19,12 +19,17 @@ welcome:
 
 ## install_jit: Install the jit package.
 install_jit:
-	@zsh scripts/install.sh
+	@echo "Installing jit"
+	@pip3 install .
+	@bash scripts/set_dir_env.sh
+	@echo "jit installed successfully"
+
 
 ## install_jit_editable: Install the jit package in editable mode.
 install_jit_editable:
 	@echo "Installing jit in editable mode"
 	@pip3 install --editable .
+	@bash scripts/set_dir_env.sh
 	@echo "jit installed successfully in editable mode"
 
 

--- a/makefile
+++ b/makefile
@@ -1,29 +1,33 @@
 .PHONY: setup check_deps install_mac_deps install_jit develop
 
 ## setup: Set up the project.
-setup: check_deps install_jit
+setup: check_deps install_jit welcome
+
+## re-install: reinstall the project without the welcome banner
+re-install: check_deps install_jit
 
 ## develop: Set up the project for development with editable install.
-develop: check_deps install_jit_editable
+develop: check_deps install_jit_editable welcome
 
 ## check_deps: Check for system dependencies like pip3, GitHub CLI, and Ollama.
 check_deps:
 	@bash scripts/check_dependencies.sh
 
+## welcome banner
+welcome:
+	@jit welcome
 
 ## install_jit: Install the jit package.
 install_jit:
 	@echo "Installing jit"
 	@pip3 install .
 	@echo "jit installed successfully"
-	@jit welcome
 
 ## install_jit_editable: Install the jit package in editable mode.
 install_jit_editable:
 	@echo "Installing jit in editable mode"
 	@pip3 install --editable .
 	@echo "jit installed successfully in editable mode"
-	@jit welcome
 
 
 ## uninstall_jit: Uninstall the jit package.

--- a/makefile
+++ b/makefile
@@ -3,8 +3,8 @@
 ## setup: Set up the project.
 setup: check_deps install_jit welcome
 
-## re-install: reinstall the project without the welcome banner
-re-install: check_deps install_jit
+## update: update & re-install the project without the welcome banner
+update: check_deps install_jit
 
 ## develop: Set up the project for development with editable install.
 develop: check_deps install_jit_editable welcome
@@ -19,9 +19,7 @@ welcome:
 
 ## install_jit: Install the jit package.
 install_jit:
-	@echo "Installing jit"
-	@pip3 install .
-	@echo "jit installed successfully"
+	@zsh scripts/install.sh
 
 ## install_jit_editable: Install the jit package in editable mode.
 install_jit_editable:

--- a/scripts/set_dir_env.sh
+++ b/scripts/set_dir_env.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/bash
 
 echo "Setting global jit dir environment variable"
 # Get the current directory
@@ -7,18 +7,50 @@ CURRENT_DIR=$(pwd)
 # Define the variable name
 JIT_DIR="JIT_DIR"
 
-# Check if the variable is already defined in the shell configuration file
-if grep -q "$JIT_DIR=" ~/.zshrc; then
-  # If the variable is already defined, update its value
-  sed "s|^$VAR_NAME=.*|$VAR_NAME=$CURRENT_DIR|" ~/.zshrc > ~/.zshrc.tmp && mv ~/.zshrc.tmp ~/.zshrc
+# Check the operating system to determine the shell configuration file
+if [ "$(uname)" == "Darwin" ]; then
+    # macOS
+    CONFIG_FILE="$HOME/.zshrc"
+elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+    # Linux
+    CONFIG_FILE="$HOME/.zshrc"
+elif [ "$(expr substr $(uname -s) 1 10)" == "MINGW32_NT" ]; then
+    # Windows
+    CONFIG_FILE="$HOME/.bashrc"
 else
-  # If the variable is not defined, add it to the file & export the variable
-  echo "$JIT_DIR=$CURRENT_DIR" >> ~/.zshrc
-  # Export the variable
-  echo "export $JIT_DIR" >> ~/.zshrc
+    echo "Unsupported operating system."
+    exit 1
 fi
 
-# Source the configuration file to apply changes
-source ~/.zshrc
+# Check if Oh My Zsh is installed
+if [ -d "$HOME/.oh-my-zsh" ]; then
+    # Oh My Zsh is installed, switch to it
+    echo "Oh My Zsh is installed. Switching to zsh script..."
+    zsh "$CURRENT_DIR/scripts/set_dir_env_zsh.sh" 
+    exit
+else
+    # Oh My Zsh is not installed
+    echo "Oh My Zsh is not installed. continuing..."
+    # You can choose to install it or take other actions here
+fi
+
+echo "HERE!"
+# Check if the variable is already defined in the shell configuration file
+if grep -q "$JIT_DIR=" "$CONFIG_FILE"; then
+    # If the variable is already defined, update its value
+    sed -i "s|^$JIT_DIR=.*|$JIT_DIR=$CURRENT_DIR|" "$CONFIG_FILE"
+else  
+    # If the variable is not defined, add it to the file & export the variable
+    echo "$JIT_DIR=$CURRENT_DIR" >> "$CONFIG_FILE"
+    # Export the variable (only for Linux and macOS)
+    if [ "$(expr substr $(uname -s) 1 5)" != "MINGW" ]; then
+        echo "export $JIT_DIR" >> "$CONFIG_FILE"
+    fi
+fi
+
+# Source the configuration file to apply changes (only for Linux and macOS)
+if [ "$(expr substr $(uname -s) 1 5)" != "MINGW" ]; then
+    source "$CONFIG_FILE"
+fi
 
 echo "jit install directory has been stored as $JIT_DIR."

--- a/scripts/set_dir_env.sh
+++ b/scripts/set_dir_env.sh
@@ -34,7 +34,6 @@ else
     # You can choose to install it or take other actions here
 fi
 
-echo "HERE!"
 # Check if the variable is already defined in the shell configuration file
 if grep -q "$JIT_DIR=" "$CONFIG_FILE"; then
     # If the variable is already defined, update its value

--- a/scripts/set_dir_env.sh
+++ b/scripts/set_dir_env.sh
@@ -1,0 +1,24 @@
+#!/bin/zsh
+
+echo "Setting global jit dir environment variable"
+# Get the current directory
+CURRENT_DIR=$(pwd)
+
+# Define the variable name
+JIT_DIR="JIT_DIR"
+
+# Check if the variable is already defined in the shell configuration file
+if grep -q "$JIT_DIR=" ~/.zshrc; then
+  # If the variable is already defined, update its value
+  sed "s|^$VAR_NAME=.*|$VAR_NAME=$CURRENT_DIR|" ~/.zshrc > ~/.zshrc.tmp && mv ~/.zshrc.tmp ~/.zshrc
+else
+  # If the variable is not defined, add it to the file & export the variable
+  echo "$JIT_DIR=$CURRENT_DIR" >> ~/.zshrc
+  # Export the variable
+  echo "export $JIT_DIR" >> ~/.zshrc
+fi
+
+# Source the configuration file to apply changes
+source ~/.zshrc
+
+echo "jit install directory has been stored as $JIT_DIR."

--- a/scripts/set_dir_env_zsh.sh
+++ b/scripts/set_dir_env_zsh.sh
@@ -1,0 +1,17 @@
+#!/bin/zsh
+
+# Check if the variable is already defined in the shell configuration file
+if grep -q "$JIT_DIR=" ~/.zshrc; then
+  # If the variable is already defined, update its value
+  sed "s|^$VAR_NAME=.*|$VAR_NAME=$CURRENT_DIR|" ~/.zshrc > ~/.zshrc.tmp && mv ~/.zshrc.tmp ~/.zshrc
+else
+  # If the variable is not defined, add it to the file & export the variable
+  echo "$JIT_DIR=$CURRENT_DIR" >> ~/.zshrc
+  # Export the variable
+  echo "export $JIT_DIR" >> ~/.zshrc
+fi
+
+# Source the configuration file to apply changes
+source ~/.zshrc
+
+echo "jit install directory has been stored as $JIT_DIR."


### PR DESCRIPTION
------------------------------------------------------- jiterated ---------------------------------------------------------

## Description
This pull request includes three improvements to our CLI and Makefile: adding an `update` command that fetches the latest changes from the repository and re-installs the JIT tool, adding a terminal-width fallback for the welcome banner, and setting up the project with a `welcome` target.

## Changes
* Added a new CLI command `update` that fetches the latest changes from the repository and re-installs the JIT tool using the Makefile.
* Added a try-except block to the `banner` function to attempt to get the terminal size, with a fallback of 80 columns if an OSError occurs.
* Added a `welcome` target that runs the `jit welcome` command after setting up the project, and added it as a dependency to the `setup` and `develop` targets.


------------------------------------------------------- jiterated ---------------------------------------------------------

## Notes - Potential future issues 
- Check if there are any updates available when running jit commands