### PR TITLE
feat/add-draft-flag

### DIFF
--- a/jit/cli.py
+++ b/jit/cli.py
@@ -6,10 +6,11 @@ import git
 from rich.logging import RichHandler
 
 from .utils import (banner, branch_is_behind, create_pull_request_via_cli,
-                    ensure_directory_and_config, generate_pr, get_repo_config,
-                    update_config)
+                    ensure_directory_and_config, generate_commit, generate_pr,
+                    get_repo_config, update_config)
 
 FORMAT = "%(message)s"
+
 
 
 
@@ -24,7 +25,24 @@ def jit(debug):
         logging.basicConfig(level=logging.INFO, format=FORMAT, datefmt="[%X]", handlers=[RichHandler()])
 
 
+@jit.command()
+@click.option('--dry', is_flag=True, help="Run the command without committing.")
+def commit(dry):
+    """Commit the staged changes in the current branch."""
+    log = logging.getLogger("rich")
+    log.debug("Starting the commit command...")
 
+    # Get the repo name and branch name
+    repo_path = os.getcwd()
+    repo = git.Repo(repo_path)
+
+    commit_message = generate_commit(repo)
+    if not dry:
+        repo.git.commit(commit_message)
+    log.info('Commit message: {}'.format(commit_message))
+
+
+    
 
 
 @jit.command()

--- a/jit/cli.py
+++ b/jit/cli.py
@@ -7,7 +7,7 @@ import git
 from rich.logging import RichHandler
 
 from .utils import (banner, branch_is_behind, create_pull_request_via_cli,
-                    ensure_directory_and_config, generate_commit, generate_pr,
+                    ensure_directory_and_config,  generate_pr,
                     get_repo_config, update_config)
 
 FORMAT = "%(message)s"
@@ -24,28 +24,6 @@ def jit(debug):
         logging.basicConfig(level=logging.DEBUG, format=FORMAT, datefmt="[%X]", handlers=[RichHandler()])
     else:
         logging.basicConfig(level=logging.INFO, format=FORMAT, datefmt="[%X]", handlers=[RichHandler()])
-
-
-@jit.command()
-@click.argument('commit_type')
-@click.option('--dry', is_flag=True, help="Run the command without committing.")
-def commit(commit_type,dry):
-    """Commit the staged changes in the current branch."""
-    log = logging.getLogger("rich")
-    log.debug("Starting the commit command...")
-
-    # Get the repo name and branch name
-    repo_path = os.getcwd()
-    repo = git.Repo(repo_path)
-
-    commit_message = generate_commit(repo, commit_type)
-    if not dry:
-        repo.index.commit(f"{commit_message}")
-    log.info('Commit message: {}'.format(commit_message))
-
-
-    
-
 
 @jit.command()
 @click.option('--dry', is_flag=True, help="Run the command without creating the PR.")

--- a/jit/cli.py
+++ b/jit/cli.py
@@ -15,20 +15,22 @@ FORMAT = "%(message)s"
 
 
 @click.group()
-def jit():
-    """jit - A tool to automate PRs."""
-
-
-@jit.command()
-@click.option('--dry', is_flag=True, help="Run the command without creating the PR.")
 @click.option('--debug', is_flag=True, help="Enable debug logging.")
-def push(dry, debug):
-    """Create a PR for the current branch."""
+def jit(debug):
+    """jit - A tool to automate PRs."""
     if debug:
         logging.basicConfig(level=logging.DEBUG, format=FORMAT, datefmt="[%X]", handlers=[RichHandler()])
     else:
         logging.basicConfig(level=logging.INFO, format=FORMAT, datefmt="[%X]", handlers=[RichHandler()])
 
+
+
+
+
+@jit.command()
+@click.option('--dry', is_flag=True, help="Run the command without creating the PR.")
+def push(dry):
+    """Create a PR for the current branch."""
     log = logging.getLogger("rich")
     log.debug("Starting the push command...")
 

--- a/jit/cli.py
+++ b/jit/cli.py
@@ -27,7 +27,8 @@ def jit(debug):
 
 @jit.command()
 @click.option('--dry', is_flag=True, help="Run the command without creating the PR.")
-def push(dry):
+@click.option('--draft', is_flag=True, help="Marks the PR as a draft.")
+def push(dry, draft):
     """Create a PR for the current branch."""
     log = logging.getLogger("rich")
     log.debug("Starting the push command...")
@@ -69,7 +70,7 @@ def push(dry):
         body = pr_description
         head_branch = branch_name
         
-        pr_link = create_pull_request_via_cli(owner, repo, title, body, head_branch, base_branch)
+        pr_link = create_pull_request_via_cli(owner, repo, title, body, head_branch, base_branch, draft)
         log.info('PR Link: {}'.format(pr_link))
 
 @jit.command()

--- a/jit/cli.py
+++ b/jit/cli.py
@@ -26,8 +26,9 @@ def jit(debug):
 
 
 @jit.command()
+@click.argument('commit_type')
 @click.option('--dry', is_flag=True, help="Run the command without committing.")
-def commit(dry):
+def commit(commit_type,dry):
     """Commit the staged changes in the current branch."""
     log = logging.getLogger("rich")
     log.debug("Starting the commit command...")
@@ -36,9 +37,9 @@ def commit(dry):
     repo_path = os.getcwd()
     repo = git.Repo(repo_path)
 
-    commit_message = generate_commit(repo)
+    commit_message = generate_commit(repo, commit_type)
     if not dry:
-        repo.git.commit(commit_message)
+        repo.index.commit(f"{commit_message}")
     log.info('Commit message: {}'.format(commit_message))
 
 

--- a/jit/constants.py
+++ b/jit/constants.py
@@ -12,30 +12,15 @@ PR_TEMPLATE = """
 * {a list of the changes made}
 """
 
-# https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commit-message-format
-COMMIT_MESSAGE_TEMPLATE = """
-<type>(<scope>): <subject>
-"""
-
 # https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#type
-COMMIT_MESSAGE_SPECIFICATION = """
-Type
-Must be one of the following:
--feat: A new feature
--fix: A bug fix
--docs: Documentation only changes
--style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
--refactor: A code change that neither fixes a bug nor adds a feature
--perf: A code change that improves performance
--test: Adding missing or correcting existing tests
--chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
+COMMIT_MESSAGE_SPECIFICATION = """Template:
+Template:
+`<type>(<scope>): <subject>` or `<type>: <subject>`
 
-Scope
-The scope could be anything specifying place of the commit change. For example $location, $browser, $compile, $rootScope, ngHref, ngClick, ngView, etc..
-
-Subject
-The subject contains succinct description of the change:
-use the imperative, present tense: "change" not "changed" nor "changes"
-don't capitalize first letter
-no dot (.) at the end
+Specifications:
+- `scope` (optional): Specifies the place of the commit, e.g.,$file_name, $location, $browser.
+- `subject`: Describes the change using:
+  - Imperative mood: "change", not "changed" or "changes".
+  - Lowercase initial letter.
+  - No period (.) at the end.
 """

--- a/jit/constants.py
+++ b/jit/constants.py
@@ -11,16 +11,3 @@ PR_TEMPLATE = """
 ## Changes
 * {a list of the changes made}
 """
-
-# https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#type
-COMMIT_MESSAGE_SPECIFICATION = """Template:
-Template:
-`<type>(<scope>): <subject>` or `<type>: <subject>`
-
-Specifications:
-- `scope` (optional): Specifies the place of the commit, e.g.,$file_name, $location, $browser.
-- `subject`: Describes the change using:
-  - Imperative mood: "change", not "changed" or "changes".
-  - Lowercase initial letter.
-  - No period (.) at the end.
-"""

--- a/jit/constants.py
+++ b/jit/constants.py
@@ -2,3 +2,40 @@ import os
 
 JIT_DIR = os.path.join(os.environ['HOME'], '.jit')
 CONFIG_FILE_PATH = os.path.join(JIT_DIR, 'config.yaml')
+
+
+PR_TEMPLATE = """
+## Description
+{a brief overview of the changes}
+
+## Changes
+* {a list of the changes made}
+"""
+
+# https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commit-message-format
+COMMIT_MESSAGE_TEMPLATE = """
+<type>(<scope>): <subject>
+"""
+
+# https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#type
+COMMIT_MESSAGE_SPECIFICATION = """
+Type
+Must be one of the following:
+-feat: A new feature
+-fix: A bug fix
+-docs: Documentation only changes
+-style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+-refactor: A code change that neither fixes a bug nor adds a feature
+-perf: A code change that improves performance
+-test: Adding missing or correcting existing tests
+-chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
+
+Scope
+The scope could be anything specifying place of the commit change. For example $location, $browser, $compile, $rootScope, ngHref, ngClick, ngView, etc..
+
+Subject
+The subject contains succinct description of the change:
+use the imperative, present tense: "change" not "changed" nor "changes"
+don't capitalize first letter
+no dot (.) at the end
+"""

--- a/jit/llm.py
+++ b/jit/llm.py
@@ -3,14 +3,12 @@ import logging
 from langchain_community.chat_models import ChatOllama
 from langchain_core.messages import HumanMessage
 
-from .prompts import (get_generate_commit_message_prompt,
-                      get_generate_diff_summary_prompt,
+from .prompts import (get_generate_diff_summary_prompt,
                       get_generate_pr_description_prompt)
 
 log = logging.getLogger("rich")
 
 local_llm = "llama3"
-commit_llm = ChatOllama(model=local_llm, json=True, temperature=0)
 diff_summary_llm = ChatOllama(model=local_llm, json=True, temperature=0)
 pr_description_llm = ChatOllama(model=local_llm, json=True, temperature=0)
 
@@ -19,12 +17,6 @@ def generate_diff_summary(diff):
     log.debug("Getting the diff summary...")
     prompt = get_generate_diff_summary_prompt(diff)
     response = diff_summary_llm.invoke([HumanMessage(content=prompt)])
-    return response.content
-
-def generate_commit_message(diffs, commit_type):
-    log.debug("Generating the commit message...")
-    prompt = get_generate_commit_message_prompt(diffs, commit_type)
-    response = commit_llm.invoke([HumanMessage(content=prompt)])
     return response.content
 
 def generate_pr_description(commit_messages, diffs):

--- a/jit/llm.py
+++ b/jit/llm.py
@@ -1,19 +1,57 @@
 import logging
+
 from langchain_community.chat_models import ChatOllama
 from langchain_core.messages import HumanMessage
+
+from .constants import (COMMIT_MESSAGE_SPECIFICATION, COMMIT_MESSAGE_TEMPLATE,
+                        PR_TEMPLATE)
+
 log = logging.getLogger("rich")
 
 local_llm = "llama3"
+commit_llm = ChatOllama(model=local_llm, json=True, temperature=0)
 diff_summary_llm = ChatOllama(model=local_llm, json=True, temperature=0)
 pr_description_llm = ChatOllama(model=local_llm, json=True, temperature=0)
 
-pr_template = """
-## Description
-{a brief overview of the changes}
+def generate_commit_message(diffs, untracked_files_contents):
+    log.debug("Generating the commit message...")
+    
+    # Construct the prompt parts based on available data
+    if diffs:
+        diffs_text = "\n".join(f"{file}:\n{diff}\n" for file, diff in diffs.items())
+        prompt_diffs = f'Here are the diffs:\n```\n{diffs_text}\n```'
+    else:
+        prompt_diffs = ""
 
-## Changes
-* {a list of the changes made}
-"""
+    if untracked_files_contents:
+        untracked_files_text = "\n".join(f"{file}:\n{content}\n" for file, content in untracked_files_contents.items())
+        prompt_untracked = f'Here are the contents of untracked files:\n```\n{untracked_files_text}\n```'
+    else:
+        prompt_untracked = ""
+
+    # Construct the base prompt
+    prompt_base = "Your job is to generate a commit message based on the information provided below."
+    prompt_commit_template = f""""Here is the commit message template:\n{COMMIT_MESSAGE_TEMPLATE}\n And here is the specification: \n```\n{COMMIT_MESSAGE_SPECIFICATION}\n```\n"""
+    prompt_end = "Please respond with the commit message ONLY."
+    
+    # Assemble the full prompt with conditional inclusion of diffs and untracked files
+    prompt = f"{prompt_base}\n{prompt_diffs}\n{prompt_untracked}\n{prompt_commit_template}\n{prompt_end}"
+    
+    # Invoke the LLM with the prompt
+    response = commit_llm.invoke([HumanMessage(content=prompt)])
+    log.debug(f"Generated commit message: {response.content}")
+    return response.content
+
+def validate_commit_message(commit_message):
+    log.debug("Validating the commit message...")
+    if not commit_message:
+        return False
+    
+    if commit_message.count('\n') < 1:
+        return False
+    
+    return True
+
 
 def generate_diff_summary(diff):
     log.debug("Getting the diff summary...")
@@ -26,9 +64,11 @@ def generate_pr_description(commit_messages, diffs):
     diff_descriptions = []
     for index, diff in enumerate(diffs):
         log.info(f'Summarizing diff {index + 1}/{len(diffs)}')
-        diff_descriptions.append(generate_diff_summary(diff))
+        current_diff_summary = generate_diff_summary(diff)
+        log.debug(f'Summary of diff {index + 1}: {current_diff_summary}')
+        diff_descriptions.append(current_diff_summary)
     
-    prompt = f'Your job is to generate a PR description based on the commit messages and diffs. You will receive the commit messages and summaries of the diffs. Here are the commit messages:\n```\n{commit_messages}\n```\nAnd here are the diffs summaries:\n```\n{diff_descriptions}\n```\nThe PR template is as follows:\n```\n{pr_template}\n```\nOnly respond with the PR description. Nothing else, not even a "Here is the PR description" message. Respond with the PR description ONLY.'
+    prompt = f'Your job is to generate a PR description based on the commit messages and diffs. You will receive the commit messages and summaries of the diffs. Here are the commit messages:\n```\n{commit_messages}\n```\nAnd here are the diffs summaries:\n```\n{diff_descriptions}\n```\nThe PR template is as follows:\n```\n{PR_TEMPLATE}\n```\nOnly respond with the PR description. Nothing else, not even a "Here is the PR description" message. Respond with the PR description ONLY.'
     log.info('Generating the PR description')
     response = pr_description_llm.invoke([HumanMessage(content=prompt)])
     return response.content

--- a/jit/llm.py
+++ b/jit/llm.py
@@ -3,8 +3,9 @@ import logging
 from langchain_community.chat_models import ChatOllama
 from langchain_core.messages import HumanMessage
 
-from .constants import (COMMIT_MESSAGE_SPECIFICATION, COMMIT_MESSAGE_TEMPLATE,
-                        PR_TEMPLATE)
+from .prompts import (get_generate_commit_message_prompt,
+                      get_generate_diff_summary_prompt,
+                      get_generate_pr_description_prompt)
 
 log = logging.getLogger("rich")
 
@@ -13,50 +14,17 @@ commit_llm = ChatOllama(model=local_llm, json=True, temperature=0)
 diff_summary_llm = ChatOllama(model=local_llm, json=True, temperature=0)
 pr_description_llm = ChatOllama(model=local_llm, json=True, temperature=0)
 
-def generate_commit_message(diffs, untracked_files_contents):
-    log.debug("Generating the commit message...")
-    
-    # Construct the prompt parts based on available data
-    if diffs:
-        diffs_text = "\n".join(f"{file}:\n{diff}\n" for file, diff in diffs.items())
-        prompt_diffs = f'Here are the diffs:\n```\n{diffs_text}\n```'
-    else:
-        prompt_diffs = ""
-
-    if untracked_files_contents:
-        untracked_files_text = "\n".join(f"{file}:\n{content}\n" for file, content in untracked_files_contents.items())
-        prompt_untracked = f'Here are the contents of untracked files:\n```\n{untracked_files_text}\n```'
-    else:
-        prompt_untracked = ""
-
-    # Construct the base prompt
-    prompt_base = "Your job is to generate a commit message based on the information provided below."
-    prompt_commit_template = f""""Here is the commit message template:\n{COMMIT_MESSAGE_TEMPLATE}\n And here is the specification: \n```\n{COMMIT_MESSAGE_SPECIFICATION}\n```\n"""
-    prompt_end = "Please respond with the commit message ONLY."
-    
-    # Assemble the full prompt with conditional inclusion of diffs and untracked files
-    prompt = f"{prompt_base}\n{prompt_diffs}\n{prompt_untracked}\n{prompt_commit_template}\n{prompt_end}"
-    
-    # Invoke the LLM with the prompt
-    response = commit_llm.invoke([HumanMessage(content=prompt)])
-    log.debug(f"Generated commit message: {response.content}")
-    return response.content
-
-def validate_commit_message(commit_message):
-    log.debug("Validating the commit message...")
-    if not commit_message:
-        return False
-    
-    if commit_message.count('\n') < 1:
-        return False
-    
-    return True
-
 
 def generate_diff_summary(diff):
     log.debug("Getting the diff summary...")
-    prompt = f'Your job is to give summaries of code changes. You will receive the one diff. Only respond with the summary of the diff. Nothing else. Please summarize the following diff:\n{diff}'
+    prompt = get_generate_diff_summary_prompt(diff)
     response = diff_summary_llm.invoke([HumanMessage(content=prompt)])
+    return response.content
+
+def generate_commit_message(diffs, commit_type):
+    log.debug("Generating the commit message...")
+    prompt = get_generate_commit_message_prompt(diffs, commit_type)
+    response = commit_llm.invoke([HumanMessage(content=prompt)])
     return response.content
 
 def generate_pr_description(commit_messages, diffs):
@@ -68,7 +36,7 @@ def generate_pr_description(commit_messages, diffs):
         log.debug(f'Summary of diff {index + 1}: {current_diff_summary}')
         diff_descriptions.append(current_diff_summary)
     
-    prompt = f'Your job is to generate a PR description based on the commit messages and diffs. You will receive the commit messages and summaries of the diffs. Here are the commit messages:\n```\n{commit_messages}\n```\nAnd here are the diffs summaries:\n```\n{diff_descriptions}\n```\nThe PR template is as follows:\n```\n{PR_TEMPLATE}\n```\nOnly respond with the PR description. Nothing else, not even a "Here is the PR description" message. Respond with the PR description ONLY.'
+    prompt = get_generate_pr_description_prompt(commit_messages, diff_descriptions)
     log.info('Generating the PR description')
     response = pr_description_llm.invoke([HumanMessage(content=prompt)])
     return response.content

--- a/jit/llm.py
+++ b/jit/llm.py
@@ -3,8 +3,7 @@ import logging
 from langchain_community.chat_models import ChatOllama
 from langchain_core.messages import HumanMessage
 
-from .prompts import (get_generate_diff_summary_prompt,
-                      get_generate_pr_description_prompt)
+from .prompts import (get_generate_diff_summary_prompt, get_generate_pr_description_prompt)
 
 log = logging.getLogger("rich")
 

--- a/jit/prompts.py
+++ b/jit/prompts.py
@@ -1,4 +1,4 @@
-from .constants import COMMIT_MESSAGE_SPECIFICATION, PR_TEMPLATE
+from .constants import PR_TEMPLATE
 
 
 def join_by_newline(items):

--- a/jit/prompts.py
+++ b/jit/prompts.py
@@ -8,16 +8,6 @@ def join_by_newline(items):
 def get_generate_diff_summary_prompt(diff):
     return f'Your job is to give summaries of code changes. You will receive the one diff. Include valuable information, such as the type of change and file name. Only respond with the summary of the diff. Nothing else. Please summarize the following diff:\n{diff}'
 
-def get_generate_commit_message_prompt(diffs, commit_type):
-    return (
-        f"Generate a detailed and specific commit message that concisely summarizes the changes shown in the diffs. "
-        f"Commit type: {commit_type}.\n"
-        f"Here are the diffs:\n"
-        f"```\n{join_by_newline(diffs)}\n```\n"
-        f"Follow these commit message specifications:\n"
-        f"```\n{COMMIT_MESSAGE_SPECIFICATION}\n```\n"
-        "Ensure the message captures all key changes. Respond with the commit message ONLY."
-    )
 
 def get_generate_pr_description_prompt(commit_messages, diff_descriptions):
     return f'Your job is to generate a PR description based on the commit messages and diffs. You will receive the commit messages and summaries of the diffs. Here are the commit messages:\n```\n{join_by_newline(commit_messages)}\n```\nAnd here are the diffs summaries:\n```\n{join_by_newline(diff_descriptions)}\n```\nThe PR template is as follows:\n```\n{PR_TEMPLATE}\n```\nOnly respond with the PR description. Nothing else, not even a "Here is the PR description" message. Respond with the PR description ONLY.'

--- a/jit/prompts.py
+++ b/jit/prompts.py
@@ -1,0 +1,23 @@
+from .constants import COMMIT_MESSAGE_SPECIFICATION, PR_TEMPLATE
+
+
+def join_by_newline(items):
+    return '\n'.join(items)
+
+
+def get_generate_diff_summary_prompt(diff):
+    return f'Your job is to give summaries of code changes. You will receive the one diff. Include valuable information, such as the type of change and file name. Only respond with the summary of the diff. Nothing else. Please summarize the following diff:\n{diff}'
+
+def get_generate_commit_message_prompt(diffs, commit_type):
+    return (
+        f"Generate a detailed and specific commit message that concisely summarizes the changes shown in the diffs. "
+        f"Commit type: {commit_type}.\n"
+        f"Here are the diffs:\n"
+        f"```\n{join_by_newline(diffs)}\n```\n"
+        f"Follow these commit message specifications:\n"
+        f"```\n{COMMIT_MESSAGE_SPECIFICATION}\n```\n"
+        "Ensure the message captures all key changes. Respond with the commit message ONLY."
+    )
+
+def get_generate_pr_description_prompt(commit_messages, diff_descriptions):
+    return f'Your job is to generate a PR description based on the commit messages and diffs. You will receive the commit messages and summaries of the diffs. Here are the commit messages:\n```\n{join_by_newline(commit_messages)}\n```\nAnd here are the diffs summaries:\n```\n{join_by_newline(diff_descriptions)}\n```\nThe PR template is as follows:\n```\n{PR_TEMPLATE}\n```\nOnly respond with the PR description. Nothing else, not even a "Here is the PR description" message. Respond with the PR description ONLY.'

--- a/jit/utils.py
+++ b/jit/utils.py
@@ -7,7 +7,7 @@ import sys
 import yaml
 
 from .constants import CONFIG_FILE_PATH, JIT_DIR
-from .llm import generate_pr_description
+from .llm import generate_commit_message, generate_pr_description
 
 log = logging.getLogger("rich")
 
@@ -162,7 +162,54 @@ def branch_is_behind(repo, base_branch, dry):
 
     log.info("Current branch is up-to-date with the remote.")
     return False
+
+def inspect_diffs(repo):
+    staging_area = repo.index
     
+    diffs_output = {}
+    untracked_files_contents = {}
+
+    # Obtain a list of file diffs between the HEAD and the index
+    diffs = staging_area.diff("HEAD")
+    
+    if diffs:
+        for diff in diffs:
+            log.info(diff.a_path)
+            log.info(diff.change_type)
+            # Handle deleted files specifically
+            if diff.deleted_file:
+                # Note that diff.a_path should still exist, showing the old path
+                diffs_output[diff.a_path] = f"Deleted file: {diff.a_path}"
+            else:
+                # Store the diff output in a dictionary keyed by file path
+                diffs_output[diff.a_path] = repo.git.diff('HEAD', diff.a_path)
+    else:
+        print("No staged changes found.")
+
+    # Handling untracked files - storing new files content, not just listing them
+    untracked_files = repo.untracked_files
+    if untracked_files:
+        for file in untracked_files:
+            try:
+                with open(os.path.join(repo.working_dir, file), 'r') as f:
+                    untracked_files_contents[file] = f.read()
+            except Exception as e:
+                print(f"Error reading file {file}: {str(e)}")
+    else:
+        print("No untracked files found.")
+
+    return diffs_output, untracked_files_contents
+    
+def generate_commit(repo):
+    log.debug("Generating the commit message...")
+    
+    diffs, untracked_files_contents = inspect_diffs(repo)
+    if not diffs and not untracked_files_contents:
+        log.error("No changes found to commit.")
+        sys.exit(1)
+    
+    commit_message = generate_commit_message(diffs, untracked_files_contents)
+    return commit_message
 
 def parse_diffs(diffs):
     log.debug("Parsing diffs...")

--- a/jit/utils.py
+++ b/jit/utils.py
@@ -186,28 +186,6 @@ def parse_diffs(diffs):
     log.debug(f"Parsed {len(individual_diffs)} diffs.")
     return individual_diffs
 
-
-def get_staged_diffs(repo):
-    log.info('Finding the staged diffs...')
-    raw_staged_diffs = repo.git.diff("HEAD", "--staged" )
-    diffs = parse_diffs(raw_staged_diffs)
-    log.info(f'Number of diffs found: {len(diffs)}')
-    return diffs
-   
-
-
-def generate_commit(repo, commit_type):
-    log.debug("Generating the commit message...")
-    
-    diffs = get_staged_diffs(repo)
-    if not diffs:
-        log.error("No changes found to commit.")
-        sys.exit(1)
-    
-    commit_message = generate_commit_message(diffs, commit_type)
-    return commit_message
-
-
 def generate_pr(repo, base_branch):
     log.info('Finding the latest commits from the current branch...')
     commits = list(repo.iter_commits(f'{base_branch}...HEAD'))

--- a/jit/utils.py
+++ b/jit/utils.py
@@ -205,21 +205,23 @@ def generate_pr(repo, base_branch):
     return pr_description
 
 
-def create_pull_request_via_cli(owner, repo, title, body, head_branch, base_branch):
+def create_pull_request_via_cli(owner, repo, title, body, head_branch, base_branch, draft):
     log.info("Creating a pull request via GitHub CLI...")
-    command = [
-        "gh", "api",
-        "--method", "POST",
-        "-H", "Accept: application/vnd.github+json",
-        "-H", "X-GitHub-Api-Version: 2022-11-28",
-        f"/repos/{owner}/{repo}/pulls",
-        "-f", f"title={title}",
-        "-f", f"body={body}",
-        "-f", f"head={head_branch}",
-        "-f", f"base={base_branch}"
-    ]
     
-    result = subprocess.run(command, text=True, capture_output=True)
+    # gh pr create [flags]
+    command = ["gh", "pr", "create"]
+    flags = [
+        f"--repo={owner}/{repo}",
+        f"--title={title}",
+        f"--body={body}",
+        f"--head={head_branch}",
+        f"--base={base_branch}",
+    ]
+    # Add the draft flag if the PR is a draft
+    if draft:
+        flags.append("--draft")
+    
+    result = subprocess.run(command + flags, text=True, capture_output=True)
     if result.returncode == 0:
         log.info("Pull request created successfully.")
         try:


### PR DESCRIPTION
## Description
This release adds a draft flag to the commit command, simplifies command logic, and improves the way we fetch staged diffs. It also includes several refactorings and bug fixes, including the addition of new prompts for summarizing code changes and generating PR descriptions. The `--draft` option marks a pull request as a draft when set to True.