### PR TITLE
Add Dependabot Configuration and Update GitHub Actions to Latest Versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 


### PR DESCRIPTION
## 📬 Description

This PR introduces a Dependabot configuration to automate GitHub Actions dependency updates and updates all existing GitHub Actions to their latest versions.

## 🎛️ Changes

- Added `.github/dependabot.yml` to enable Dependabot for GitHub Actions.
- Updated `actions/checkout` to `v4`.
- Updated `actions/setup-python` to `v5`.

---

Please review the changes and let me know if any adjustments are needed. Thank you!
